### PR TITLE
fix: correct import path in server.js to avoid double src reference

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,5 @@
 // Express Imports
-import app from "../src/app.js";
+import app from "./app.js";
 
 // Set the server port from environment variable or default to 5000
 const PORT = process.env.PORT || 5000;


### PR DESCRIPTION
fix: correct import path in server.js to avoid double src reference